### PR TITLE
Updating glog path

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // A Binder translates between string parameters and Go data structures.

--- a/cache/inmemory.go
+++ b/cache/inmemory.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/robfig/go-cache"
+	"github.com/teltech/glog"
 )
 
 type InMemoryCache struct {

--- a/cache/memcached.go
+++ b/cache/memcached.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/robfig/gomemcache/memcache"
+	"github.com/teltech/glog"
 )
 
 // Wraps the Memcached client to meet the Cache interface.

--- a/cache/serialization.go
+++ b/cache/serialization.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // Serialize transforms the given value into bytes following these rules:

--- a/config.go
+++ b/config.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/robfig/config"
+	"github.com/teltech/glog"
 )
 
 // This handles the parsing of app.conf

--- a/controller.go
+++ b/controller.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"golang.org/x/net/websocket"
 )
 

--- a/fakeapp_test.go
+++ b/fakeapp_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 type Hotel struct {

--- a/harness/app.go
+++ b/harness/app.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/harness/build.go
+++ b/harness/build.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 
@@ -259,7 +259,7 @@ package main
 import (
 	"flag"
 	"reflect"
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"{{range $k, $v := $.ImportPaths}}
 	{{$v}} "{{$k}}"{{end}}
 )

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/harness/reflect.go
+++ b/harness/reflect.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/http.go
+++ b/http.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 type Request struct {

--- a/i18n.go
+++ b/i18n.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/robfig/config"
+	"github.com/teltech/glog"
 )
 
 const (

--- a/invoker.go
+++ b/invoker.go
@@ -3,7 +3,7 @@ package revel
 import (
 	"reflect"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"golang.org/x/net/websocket"
 )
 

--- a/modules/db/app/db.go
+++ b/modules/db/app/db.go
@@ -12,7 +12,7 @@ package db
 import (
 	"database/sql"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/modules/jobs/app/jobs/job.go
+++ b/modules/jobs/app/jobs/job.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/golang/glog"
 	"github.com/robfig/cron"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/modules/static/app/controllers/static.go
+++ b/modules/static/app/controllers/static.go
@@ -5,7 +5,7 @@ import (
 	fpath "path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 )
 

--- a/panic.go
+++ b/panic.go
@@ -3,7 +3,7 @@ package revel
 import (
 	"runtime/debug"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // PanicFilter wraps the action invocation in a protective defer blanket that

--- a/params.go
+++ b/params.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // Params provides a unified view of the request params.

--- a/results.go
+++ b/results.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 type Result interface {

--- a/revel.go
+++ b/revel.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/robfig/config"
 	"github.com/robfig/humanize"
+	"github.com/teltech/glog"
 )
 
 const (

--- a/revel/build.go
+++ b/revel/build.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 	"github.com/teltech/revel/harness"
 )

--- a/revel/run.go
+++ b/revel/run.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 	"github.com/teltech/revel/harness"
 )

--- a/revel/test.go
+++ b/revel/test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"github.com/teltech/revel"
 	"github.com/teltech/revel/harness"
 	"github.com/teltech/revel/modules/testrunner/app/controllers"

--- a/router.go
+++ b/router.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 type Route struct {

--- a/samples/booking/app/controllers/gorp.go
+++ b/samples/booking/app/controllers/gorp.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"log"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	r "github.com/teltech/revel"
 	db "github.com/teltech/revel/modules/db/app"
 	"github.com/teltech/revel/samples/booking/app/models"

--- a/server.go
+++ b/server.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 	"golang.org/x/net/websocket"
 )
 

--- a/session.go
+++ b/session.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/streadway/simpleuuid"
+	"github.com/teltech/glog"
 )
 
 // A signed cookie (and thus limited to 4kb in size).

--- a/templatefuncs.go
+++ b/templatefuncs.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 var (

--- a/templateloader.go
+++ b/templateloader.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // TemplateLoader handles loading of templates, by passing them to the

--- a/util.go
+++ b/util.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 // ExecuteTemplate renders a template into a string.

--- a/validation.go
+++ b/validation.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"runtime"
 
-	"github.com/golang/glog"
+	"github.com/teltech/glog"
 )
 
 type ValidationError struct {

--- a/watcher.go
+++ b/watcher.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/rjeczalik/notify"
+	"github.com/teltech/glog"
 )
 
 // Listener is an interface for receivers of filesystem events.


### PR DESCRIPTION
We need to use our fork of the `glog` as it contains code for deleting rotated log files.